### PR TITLE
Add bump2version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,26 @@
+[bumpversion]
+current_version = 0.1.0
+commit = True
+tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
+# ((?P<release>[a-z]+)(?P<build>\d+))? # for alpha releases
+
+serialize = 
+	# {major}.{minor}.{patch}{release}{build}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+optional_value = ''
+first_value = a
+values = 
+	a
+	''
+
+[bumpversion:file:pyproject.toml]
+
+[bumpversion:file:nicenumber/__init__.py]
+
+[bumpversion:file:tests/test_nicenumber.py]
+
+search = {current_version}
+replace = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,12 +1,9 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.2.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-# ((?P<release>[a-z]+)(?P<build>\d+))? # for alpha releases
-
 serialize = 
-	# {major}.{minor}.{patch}{release}{build}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
@@ -21,6 +18,5 @@ values =
 [bumpversion:file:nicenumber/__init__.py]
 
 [bumpversion:file:tests/test_nicenumber.py]
-
 search = {current_version}
 replace = {new_version}

--- a/nicenumber/__init__.py
+++ b/nicenumber/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 
 import logging
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,6 +21,14 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
+name = "bump2version"
+version = "1.0.1"
+description = "Version-bump your software with a single command!"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
@@ -157,7 +165,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "7e243dad18e7f5e5fd23737687127ae3ea7d854b0f6193907f0a2575921449c1"
+content-hash = "eb611c082ca46f05fead7d7a274af083b272e0565c7b262d4038c89dea794b57"
 
 [metadata.files]
 atomicwrites = [
@@ -167,6 +175,10 @@ atomicwrites = [
 attrs = [
     {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
     {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
+]
+bump2version = [
+    {file = "bump2version-1.0.1-py2.py3-none-any.whl", hash = "sha256:37f927ea17cde7ae2d7baf832f8e80ce3777624554a653006c9144f8017fe410"},
+    {file = "bump2version-1.0.1.tar.gz", hash = "sha256:762cb2bfad61f4ec8e2bdf452c7c267416f8c70dd9ecb1653fd0bbb01fa936e6"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nicenumber"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python package to make numbers nice"
 authors = ["Cameron Harris <camharris22@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ pandas = "^1.2.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.2"
+bump2version = "^1.0.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_nicenumber.py
+++ b/tests/test_nicenumber.py
@@ -7,7 +7,7 @@ from pytest import raises
 
 
 def test_version():
-    assert __version__ == '0.1.0'
+    assert __version__ == '0.2.0'
 
 def check_expected_result(func, vals : list):
     """Call function with kw args for each dict in list


### PR DESCRIPTION
Added bump2version to allow managing version strings anywhere in the project, as opposed to just in pyproject.toml with poetry